### PR TITLE
Pin watson-developer-cloud SDK to prevent breakage.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.10.1
 flask-socketio==2.9.2
-watson_developer_cloud>=1.4.1
+watson_developer_cloud==1.5
 SpeechRecognition==3.8.1
 python-dotenv==0.8.2


### PR DESCRIPTION
The 2.0 version of Watson python SDK contains breaking changes.
Pin the version for now, and provide fixes in a later patch.