### PR TITLE
Update runtime.txt

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.4
+python-3.7.7


### PR DESCRIPTION
The version has to be updated, as latest python buildpack in IBM Cloud supports only two latest versions. With the current value deploy fails